### PR TITLE
Enable Vulkan for macOS, fix descriptor sets running out of memory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 
 [dependencies]
 ash = "0.33.3"
-gpu-allocator = { git = "https://github.com/jhvst/gpu-allocator", features = ["vulkan"] }
+gpu-allocator = { git = "https://github.com/Traverse-Research/gpu-allocator" }
 rayon = "1.5.1"
 rspirv = "0.10.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ exclude = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ash = "0.32.1"
-gpu-allocator = "0.8.0"
+ash = "0.33.2"
+gpu-allocator = "0.9.0"
 rayon = "1.5.1"
 rspirv = "0.10.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ exclude = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ash = "0.33.2"
-gpu-allocator = "0.9.0"
+ash = "0.33.3"
+gpu-allocator = { git = "https://github.com/jhvst/gpu-allocator", features = ["vulkan"] }
 rayon = "1.5.1"
 rspirv = "0.10.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 
 [dependencies]
 ash = "0.33.3"
-gpu-allocator = { git = "https://github.com/Traverse-Research/gpu-allocator" }
+gpu-allocator = "0.10.0"
 rayon = "1.5.1"
 rspirv = "0.10.0"
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -6,7 +6,7 @@ use gpu_allocator::{MemoryLocation, vulkan::*};
 
 pub struct Buffer<'a, 'b>  {
     pub buffer: vk::Buffer,
-    pub allocation: SubAllocation,
+    pub allocation: Allocation,
     pub device_size: vk::DeviceSize,
 
     device: &'a ash::Device,

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,23 +1,23 @@
-use std::{error::Error, sync::{RwLock}};
+use std::{error::Error, sync::RwLock};
 
-use ash::{version::DeviceV1_0, vk};
-use gpu_allocator::{AllocationCreateDesc, MemoryLocation, VulkanAllocator};
+use ash::vk;
+use gpu_allocator::{MemoryLocation, vulkan::*};
 
 
 pub struct Buffer<'a, 'b>  {
     pub buffer: vk::Buffer,
-    pub allocation: gpu_allocator::SubAllocation,
+    pub allocation: SubAllocation,
     pub device_size: vk::DeviceSize,
 
     device: &'a ash::Device,
-    allocator: &'b Option<RwLock<gpu_allocator::VulkanAllocator>>,
+    allocator: &'b Option<RwLock<Allocator>>,
 }
 
 impl <'a, 'b> Buffer<'_, '_> {
 
     pub fn new(
         device: &'a ash::Device,
-        allocator: &'b Option<RwLock<VulkanAllocator>>,
+        allocator: &'b Option<RwLock<Allocator>>,
         device_size: vk::DeviceSize,
         usage: vk::BufferUsageFlags,
         memory_usage: MemoryLocation,

--- a/src/command.rs
+++ b/src/command.rs
@@ -64,13 +64,11 @@ impl <'a> Command<'_> {
             .descriptor_pool(descriptor_pool)
             .set_layouts(set_layouts);
 
-        let descriptor_sets = (0..command_buffer_count)
-            .into_iter()
-            .filter_map(|_| match unsafe { device.allocate_descriptor_sets(&descriptor_set_info) } {
-                Ok(ds) => Some(ds[0]),
-                Err(_) => None,
-            })
-            .collect();
+        let mut descriptor_sets = vec![];
+        for _ in 0..command_buffer_count {
+            let sets = unsafe { device.allocate_descriptor_sets(&descriptor_set_info) }?;
+            descriptor_sets.push(sets[0]);
+        }
 
         let command_pool = Command::command_pool(device, queue_family_index)?;
         let command_buffers = Command::allocate_command_buffers(device, command_pool, command_buffer_count)?;

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,6 +1,6 @@
 use std::error::Error;
 
-use ash::{version::DeviceV1_0, vk};
+use ash::vk;
 
 
 pub struct Command<'a> {

--- a/src/fence.rs
+++ b/src/fence.rs
@@ -1,6 +1,6 @@
 use std::error::Error;
 
-use ash::{version::DeviceV1_0, vk};
+use ash::vk;
 
 
 pub struct Fence {

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -1,7 +1,7 @@
 use std::{error::Error, ffi::CString, sync::{RwLock}};
 
-use ash::{version::{InstanceV1_0, InstanceV1_1}, vk};
-use gpu_allocator::{VulkanAllocator, VulkanAllocatorCreateDesc};
+use ash::vk;
+use gpu_allocator::vulkan::*;
 
 use crate::{Compute, fence::Fence};
 
@@ -122,7 +122,7 @@ impl GPU {
 
         let device = instance.create_device(self.physical, &device_info, None)?;
 
-        let allocator_create_info = VulkanAllocatorCreateDesc {
+        let allocator_create_info = Allocator {
             physical_device: self.physical,
             device: device.clone(),
             instance: instance.clone(),
@@ -130,7 +130,7 @@ impl GPU {
             buffer_device_address: false,
         };
 
-        let allocator = VulkanAllocator::new(&allocator_create_info);
+        let allocator = Allocator::new(&allocator_create_info);
 
         let fences = queue_infos
             .iter()

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -122,7 +122,7 @@ impl GPU {
 
         let device = instance.create_device(self.physical, &device_info, None)?;
 
-        let allocator_create_info = Allocator {
+        let allocator_create_info = AllocatorCreateDesc {
             physical_device: self.physical,
             device: device.clone(),
             instance: instance.clone(),
@@ -130,7 +130,7 @@ impl GPU {
             buffer_device_address: false,
         };
 
-        let allocator = Allocator::new(&allocator_create_info);
+        let allocator = Allocator::new(&allocator_create_info)?;
 
         let fences = queue_infos
             .iter()

--- a/src/shader.rs
+++ b/src/shader.rs
@@ -1,6 +1,6 @@
 use std::{error::Error, ffi::CString, io};
 
-use ash::{version::DeviceV1_0, vk};
+use ash::vk;
 
 use crate::compute::Compute;
 

--- a/src/vulkan.rs
+++ b/src/vulkan.rs
@@ -1,6 +1,6 @@
 use std::{borrow::BorrowMut, error::Error};
 
-use ash::{Entry, extensions::ext::DebugUtils, version::{EntryV1_0, InstanceV1_0}, vk};
+use ash::{Entry, extensions::ext::DebugUtils, vk};
 
 use crate::{compute::Compute, debug_layer::{DebugLayer, DebugOption}, gpu::GPU};
 
@@ -33,7 +33,7 @@ impl Vulkan {
             .create_instance(&vk::InstanceCreateInfo::builder()
                 .push_next(info.borrow_mut())
                 .application_info(&vk::ApplicationInfo {
-                    api_version: vk::make_version(1, 2, 0),
+                    api_version: vk::make_api_version(0, 1, 2, 0),
                     engine_version: 0,
                     ..Default::default()
                 })
@@ -41,9 +41,8 @@ impl Vulkan {
                 .enabled_extension_names(&[DebugUtils::name().as_ptr()])
             , None)? };
 
-        println!("Instance created");
         match _entry.try_enumerate_instance_version()? {
-            Some(v) => println!("Using Vulkan {}.{}.{}", vk::version_major(v), vk::version_minor(v), vk::version_patch(v)),
+            Some(v) => println!("Using Vulkan {}.{}.{}", vk::api_version_major(v), vk::api_version_minor(v), vk::api_version_patch(v)),
             None => println!("Using Vulkan 1.0"),
         };
 


### PR DESCRIPTION
To enable Vulkan for macOS, an upstream change had to be made for gpu-allocator, see: https://github.com/Traverse-Research/gpu-allocator/pull/69. Coincidentally, this allows the ash dependency to be upgraded to the latest version.

Furthermore, some platforms ran out of memory silently when building description sets. This was fixed by using a loop instead of an iterator when creating the descriptors.